### PR TITLE
将桌面自动化改造为 MCP 插件

### DIFF
--- a/apps/scream-code/package.json
+++ b/apps/scream-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scream-code",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "The Starting Point for Next-Gen Agents",
   "license": "MIT",
   "author": "ScreamCli",
@@ -23,7 +23,8 @@
     "tui"
   ],
   "bin": {
-    "scream": "dist/main.mjs"
+    "scream": "dist/main.mjs",
+    "scream-desktop-mcp": "dist/mcp-servers/desktop-server.mjs"
   },
   "files": [
     "dist",
@@ -67,11 +68,13 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@scream-cli/agent-core": "workspace:^",
     "@scream-cli/config": "workspace:^",
     "@scream-cli/migration-legacy": "workspace:^",
     "@scream-cli/scream-code-sdk": "workspace:^",
     "@scream-cli/scream-telemetry": "workspace:^",
     "@scream-code/memory": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/semver": "^7.7.0",
     "tsx": "^4.21.0"
   },

--- a/apps/scream-code/src/cli/agent-desktop.ts
+++ b/apps/scream-code/src/cli/agent-desktop.ts
@@ -1,0 +1,136 @@
+/**
+ * agent-desktop lifecycle management — install, detect.
+ *
+ * Platform-aware detection of the `agent-desktop` native binary and
+ * installation helper. Used by the /mcp panel to set up the Desktop
+ * Automation MCP server.
+ */
+
+import { exec, execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+// ── Detection ────────────────────────────────────────────────────────────
+
+export interface AgentDesktopStatus {
+  installed: boolean;
+  version?: string;
+  /**
+   * Absolute path to the native binary, or the `agent-desktop` CLI wrapper
+   * when resolved via npm.
+   */
+  binaryPath?: string;
+}
+
+/**
+ * Check whether the agent-desktop native binary is available (async).
+ *
+ * Resolution order:
+ * 1. `createRequire` lookup — works when agent-desktop is a project dependency.
+ * 2. Global `agent-desktop` on PATH — works for global installs.
+ */
+export async function checkAgentDesktop(): Promise<AgentDesktopStatus> {
+  // Try npm dependency (project-level install, like grok-cli)
+  let jsPath: string | undefined;
+  try {
+    const require = createRequire(import.meta.url);
+    const packagePath = require.resolve('agent-desktop/package.json');
+    const binDir = join(dirname(packagePath), 'bin');
+    jsPath = join(binDir, 'agent-desktop.js');
+  } catch {
+    // Not found as project dependency — fall through to global check
+  }
+
+  if (jsPath && existsSync(jsPath)) {
+    return tryVersion(jsPath);
+  }
+
+  // Fallback: check global install
+  return tryVersion();
+}
+
+async function tryVersion(jsPath?: string): Promise<AgentDesktopStatus> {
+  return new Promise<AgentDesktopStatus>((resolve) => {
+    if (jsPath) {
+      execFile(
+        process.execPath,
+        [jsPath, 'version'],
+        { timeout: 5_000, windowsHide: true },
+        (_error, stdout) => {
+          if (_error) { resolve({ installed: false }); return; }
+          try {
+            const parsed = JSON.parse(stdout.trim()) as { version?: string };
+            resolve({ installed: true, version: parsed.version, binaryPath: jsPath });
+          } catch {
+            resolve({ installed: true, binaryPath: jsPath });
+          }
+        },
+      );
+    } else {
+      exec(
+        'agent-desktop version 2>&1',
+        { timeout: 5_000, windowsHide: true },
+        (_error, stdout) => {
+          if (_error) { resolve({ installed: false }); return; }
+          try {
+            const parsed = JSON.parse(stdout.trim()) as { version?: string };
+            resolve({ installed: true, version: parsed.version });
+          } catch {
+            resolve({ installed: true });
+          }
+        },
+      );
+    }
+  });
+}
+
+/** Sync version of the check (for initial UI rendering). */
+export function checkAgentDesktopSync(): AgentDesktopStatus {
+  try {
+    const require = createRequire(import.meta.url);
+    const packagePath = require.resolve('agent-desktop/package.json');
+    const binDir = join(dirname(packagePath), 'bin');
+    const jsPath = join(binDir, 'agent-desktop.js');
+    if (existsSync(jsPath)) {
+      return { installed: true, binaryPath: jsPath };
+    }
+  } catch {
+    // not a project dependency
+  }
+  return { installed: false };
+}
+
+// ── Installation ─────────────────────────────────────────────────────────
+
+export function installAgentDesktop(): Promise<{ ok: boolean; output: string }> {
+  return new Promise((resolve) => {
+    exec(
+      'npm install -g agent-desktop',
+      { timeout: 60_000, windowsHide: true },
+      (error, stdout, stderr) => {
+        if (error) {
+          resolve({ ok: false, output: stderr.trim() || error.message });
+        } else {
+          resolve({ ok: true, output: stdout.trim() });
+        }
+      },
+    );
+  });
+}
+
+export function updateAgentDesktop(): Promise<{ ok: boolean; output: string }> {
+  return new Promise((resolve) => {
+    exec(
+      'npm install -g agent-desktop@latest',
+      { timeout: 60_000, windowsHide: true },
+      (error, stdout, stderr) => {
+        if (error) {
+          resolve({ ok: false, output: stderr.trim() || error.message });
+        } else {
+          resolve({ ok: true, output: stdout.trim() });
+        }
+      },
+    );
+  });
+}

--- a/apps/scream-code/src/mcp-servers/desktop-server.ts
+++ b/apps/scream-code/src/mcp-servers/desktop-server.ts
@@ -1,0 +1,428 @@
+/**
+ * agent-desktop MCP Server
+ *
+ * Stdio MCP server that wraps the agent-desktop native binary.  Exposes
+ * 12 computer_* tools — one per agent-desktop subcommand — and translates
+ * between MCP JSON-RPC and the binary's CLI/JSON interface.
+ */
+
+import { execFile } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+// ── Tool input schemas (Zod) ───────────────────────────────────────────
+
+const ComputerSnapshotInputSchema = z.object({
+  app: z.string().optional(),
+  window_id: z.string().optional(),
+  interactive_only: z.boolean().optional(),
+  include_bounds: z.boolean().optional(),
+  compact: z.boolean().optional(),
+  max_depth: z.number().optional(),
+  surface: z.string().optional(),
+});
+
+const ComputerScreenshotInputSchema = z.object({
+  output_path: z.string().optional(),
+  app: z.string().optional(),
+  window_id: z.string().optional(),
+});
+
+const ComputerClickInputSchema = z.object({
+  ref: z.string().optional(),
+  x: z.number().optional(),
+  y: z.number().optional(),
+  button: z.enum(['left', 'right', 'middle']).optional(),
+  count: z.enum(['single', 'double', 'triple']).optional(),
+});
+
+const ComputerMouseMoveInputSchema = z.object({
+  ref: z.string().optional(),
+  x: z.number().optional(),
+  y: z.number().optional(),
+  duration_ms: z.number().optional(),
+});
+
+const ComputerTypeInputSchema = z.object({
+  ref: z.string(),
+  text: z.string(),
+});
+
+const ComputerPressInputSchema = z.object({
+  key: z.string(),
+  app: z.string().optional(),
+});
+
+const ComputerScrollInputSchema = z.object({
+  ref: z.string(),
+  direction: z.enum(['left', 'right', 'up', 'down']),
+  amount: z.number().optional(),
+});
+
+const ComputerLaunchInputSchema = z.object({
+  app: z.string(),
+  timeout_ms: z.number().optional(),
+});
+
+const ComputerListWindowsInputSchema = z.object({
+  app: z.string().optional(),
+});
+
+const ComputerFocusWindowInputSchema = z.object({
+  window_id: z.string().optional(),
+  app: z.string().optional(),
+  title: z.string().optional(),
+});
+
+const ComputerGetInputSchema = z.object({
+  ref: z.string(),
+  property: z.enum(['text', 'role', 'value', 'title', 'bounds', 'states']).optional(),
+});
+
+const ComputerWaitInputSchema = z.object({
+  milliseconds: z.number().optional(),
+  element: z.string().optional(),
+  window: z.string().optional(),
+  text: z.string().optional(),
+  timeout_ms: z.number().optional(),
+  menu_open: z.string().optional(),
+  menu_closed: z.string().optional(),
+});
+
+// ── Binary resolution ──────────────────────────────────────────────────
+
+interface AgentDesktopInvoker {
+  command: string;
+  prefixArgs: string[];
+  available: boolean;
+}
+
+function resolveAgentDesktopInvoker(): AgentDesktopInvoker {
+  try {
+    const require = createRequire(import.meta.url);
+    const packagePath = require.resolve('agent-desktop/package.json');
+    const jsPath = join(dirname(packagePath), 'bin', 'agent-desktop.js');
+    return { command: process.execPath, prefixArgs: [jsPath], available: true };
+  } catch {
+    // Global install: binary is on PATH even though createRequire can't see it.
+    return { command: 'agent-desktop', prefixArgs: [], available: true };
+  }
+}
+
+// ── Environment allowlist ──────────────────────────────────────────────
+
+const ENV_ALLOWLIST = [
+  'HOME', 'LANG', 'LC_ALL', 'LC_CTYPE', 'LOGNAME', 'PATH',
+  'SHELL', 'TERM', 'TERM_PROGRAM', 'TERM_PROGRAM_VERSION',
+  'TMP', 'TMPDIR', 'TEMP', 'USER', '__CF_USER_TEXT_ENCODING',
+];
+
+function buildEnv(): Record<string, string> {
+  const env: Record<string, string> = { FORCE_COLOR: '0' };
+  for (const key of ENV_ALLOWLIST) {
+    if (process.env[key]) env[key] = process.env[key];
+  }
+  return env;
+}
+
+// ── Runner ─────────────────────────────────────────────────────────────
+
+interface RunResult {
+  success: boolean;
+  data: unknown;
+  error?: string;
+}
+
+function runDesktop(args: string[]): Promise<RunResult> {
+  const invoker = resolveAgentDesktopInvoker();
+  return new Promise((resolve) => {
+    execFile(
+      invoker.command,
+      [...invoker.prefixArgs, ...args],
+      { env: buildEnv(), maxBuffer: 10 * 1024 * 1024, timeout: 120_000 },
+      (error, stdout, stderr) => {
+        // Try parsing JSON output even on failure — agent-desktop writes
+        // structured errors to stdout.
+        if (stdout.trim()) {
+          try {
+            const parsed = JSON.parse(stdout.trim());
+            if (parsed && typeof parsed === 'object') {
+              resolve({
+                success: parsed.ok === true && !error,
+                data: parsed,
+                error: !parsed.ok ? (parsed.error?.message ?? JSON.stringify(parsed.error)) : error?.message,
+              });
+              return;
+            }
+          } catch { /* fall through */ }
+        }
+        if (error) {
+          const detail = stderr?.trim() || error.message;
+          resolve({ success: false, data: null, error: detail });
+          return;
+        }
+        resolve({ success: true, data: stdout.trim() });
+      },
+    );
+  });
+}
+
+function formatError(result: RunResult): string {
+  if (!result.error) return 'Unknown agent-desktop error';
+  const lower = result.error.toLowerCase();
+  if (lower.includes('accessibility'))
+    return `${result.error}\nEnable Accessibility permission for your terminal in System Settings > Privacy & Security > Accessibility.`;
+  if (lower.includes('supports macos only') || lower.includes('macos only'))
+    return `${result.error}\nagent-desktop supports macOS only.`;
+  return result.error;
+}
+
+function isMacOS(): boolean {
+  return process.platform === 'darwin';
+}
+
+function macOnlyError(): string {
+  return 'Desktop automation is only available on macOS. agent-desktop does not support this platform.';
+}
+
+// ── Argument mapping ───────────────────────────────────────────────────
+
+interface ArgMapping {
+  /** Positional argument field names, in order. */
+  positional?: string[];
+  /** Map input field names → CLI flag names (without -- prefix). */
+  flags?: Record<string, string>;
+}
+
+function buildCliArgs(
+  subcommand: string,
+  input: Record<string, unknown>,
+  mapping: ArgMapping,
+): string[] {
+  const args = [subcommand];
+  if (mapping.positional) {
+    for (const key of mapping.positional) {
+      const value = input[key];
+      if (value !== undefined && value !== null) args.push(String(value));
+    }
+  }
+  if (mapping.flags) {
+    for (const [key, flagName] of Object.entries(mapping.flags)) {
+      const value = input[key];
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'boolean') {
+        if (value) args.push('--' + flagName);
+      } else {
+        args.push('--' + flagName, String(value));
+      }
+    }
+  }
+  return args;
+}
+
+// ── Server setup ───────────────────────────────────────────────────────
+
+const server = new McpServer(
+  { name: 'agent-desktop', version: '0.1.0' },
+  { capabilities: { tools: {} } },
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ToArgs = (input: any) => string[];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function register(name: any, description: string, inputSchema: any, toArgs: ToArgs) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (server.registerTool as any)(name, { description, inputSchema },
+    async (input: any) => {
+      if (!isMacOS()) return { content: [{ type: 'text', text: macOnlyError() }], isError: true };
+
+      const invoker = resolveAgentDesktopInvoker();
+      if (!invoker.available) {
+        return {
+          content: [{ type: 'text', text: 'agent-desktop is not installed. Run /mcp and install Desktop Automation to set it up.' }],
+          isError: true,
+        };
+      }
+
+      let args: string[];
+      try {
+        args = toArgs(input ?? {});
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `Invalid arguments: ${err instanceof Error ? err.message : String(err)}` }],
+          isError: true,
+        };
+      }
+
+      const result = await runDesktop(args);
+      if (!result.success) {
+        return { content: [{ type: 'text', text: formatError(result) }], isError: true };
+      }
+      const output = typeof result.data === 'string' ? result.data : JSON.stringify(result.data, null, 2);
+      return { content: [{ type: 'text', text: output }] };
+    },
+  );
+}
+
+// ── Register all tools ─────────────────────────────────────────────────
+
+register('computer_snapshot',
+  'Capture an accessibility-tree snapshot of the macOS desktop. Returns stable element refs (e.g. @e1, @e2) that can be used with computer_click, computer_type, computer_scroll, and computer_get.',
+  ComputerSnapshotInputSchema,
+  (input) => buildCliArgs('snapshot', input, {
+    flags: {
+      app: 'app',
+      window_id: 'window-id',
+      interactive_only: 'interactive-only',
+      include_bounds: 'include-bounds',
+      compact: 'compact',
+      max_depth: 'max-depth',
+      surface: 'surface',
+    },
+  }),
+);
+
+register('computer_screenshot',
+  'Take a PNG screenshot of the macOS desktop, a specific window, or a specific application.',
+  ComputerScreenshotInputSchema,
+  (input) => buildCliArgs('screenshot', input, {
+    positional: ['output_path'],
+    flags: { app: 'app', window_id: 'window-id' },
+  }),
+);
+
+register('computer_click',
+  'Click a desktop UI element by ref (from computer_snapshot) or by screen coordinates. Supports left/right/middle button and single/double/triple click.',
+  ComputerClickInputSchema,
+  (input) => {
+    if (input.ref) return ['click', input.ref];
+    if (input.x !== undefined && input.y !== undefined) {
+      const args = ['mouse-click', '--xy', `${input.x},${input.y}`];
+      if (input.button) args.push('--button', input.button);
+      if (input.count) args.push('--count', input.count);
+      return args;
+    }
+    throw new Error('Either ref or x,y coordinates are required');
+  },
+);
+
+register('computer_mouse_move',
+  'Move the mouse to a desktop element (by ref) or to absolute screen coordinates.',
+  ComputerMouseMoveInputSchema,
+  (input) => {
+    if (input.ref) return ['hover', input.ref];
+    if (input.x !== undefined && input.y !== undefined) {
+      return ['mouse-move', '--xy', `${input.x},${input.y}`];
+    }
+    throw new Error('Either ref or x,y coordinates are required');
+  },
+);
+
+register('computer_type',
+  'Type text into a focused desktop UI element identified by ref from computer_snapshot.',
+  ComputerTypeInputSchema,
+  (input) => buildCliArgs('type', input, {
+    positional: ['ref', 'text'],
+  }),
+);
+
+register('computer_press',
+  'Press a key or key chord (e.g. cmd+s, Enter, Escape) on the macOS desktop. Use for keyboard shortcuts.',
+  ComputerPressInputSchema,
+  (input) => buildCliArgs('press', input, {
+    positional: ['key'],
+    flags: { app: 'app' },
+  }),
+);
+
+register('computer_scroll',
+  'Scroll a desktop UI element (by ref from computer_snapshot) in the specified direction.',
+  ComputerScrollInputSchema,
+  (input) => buildCliArgs('scroll', input, {
+    positional: ['ref'],
+    flags: { direction: 'direction', amount: 'amount' },
+  }),
+);
+
+register('computer_launch',
+  'Launch a macOS application by name and optionally wait for its window to appear.',
+  ComputerLaunchInputSchema,
+  (input) => buildCliArgs('launch', input, {
+    positional: ['app'],
+    flags: { timeout_ms: 'timeout' },
+  }),
+);
+
+register('computer_list_windows',
+  'List open windows on the macOS desktop, optionally filtered by application. Returns window IDs for computer_focus_window.',
+  ComputerListWindowsInputSchema,
+  (input) => buildCliArgs('list-windows', input, {
+    flags: { app: 'app' },
+  }),
+);
+
+register('computer_focus_window',
+  'Focus a macOS window by ID, app name, or title. Use after computer_list_windows.',
+  ComputerFocusWindowInputSchema,
+  (input) => buildCliArgs('focus-window', input, {
+    flags: { window_id: 'window-id', app: 'app', title: 'title' },
+  }),
+);
+
+register('computer_get',
+  'Read properties (text, value, title, bounds, role, states) from a desktop element ref.',
+  ComputerGetInputSchema,
+  (input) => buildCliArgs('get', input, {
+    positional: ['ref'],
+    flags: { property: 'property' },
+  }),
+);
+
+register('computer_wait',
+  'Wait for a condition on the macOS desktop: delay, element appearance, window, text, or menu open/close.',
+  ComputerWaitInputSchema,
+  (input) => buildCliArgs('wait', input, {
+    positional: ['milliseconds'],
+    flags: {
+      element: 'element',
+      window: 'window',
+      text: 'text',
+      timeout_ms: 'timeout',
+      menu_open: 'menu',
+      menu_closed: 'menu-closed',
+    },
+  }),
+);
+
+// ── Skill tool ────────────────────────────────────────────────────────
+
+const ComputerSkillInputSchema = z.object({
+  full: z.boolean().optional().describe('Include all reference files (commands, workflows, macos internals)'),
+});
+
+register('computer_skill',
+  'CRITICAL: Call this FIRST before any desktop automation. Returns the complete agent-desktop workflow guide: the observe-act loop (skeleton→drill→act→verify), ref system (@e1, @e2), command quick reference, error codes with recovery hints, and key principles. Use this to understand how to navigate and control the desktop effectively.',
+  ComputerSkillInputSchema,
+  (input) => {
+    const args = ['skills', 'get', 'desktop'];
+    if (input.full) args.push('--full');
+    return args;
+  },
+);
+
+// ── Start ──────────────────────────────────────────────────────────────
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  console.error('agent-desktop MCP server failed to start:', err);
+  process.exit(1);
+});

--- a/apps/scream-code/src/tui/commands/mcp.ts
+++ b/apps/scream-code/src/tui/commands/mcp.ts
@@ -4,6 +4,7 @@
  * 查看已安装的 MCP 服务器状态，一键安装推荐服务器。 */
 
 import { writeFile, readFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import {
@@ -17,6 +18,7 @@ import {
 import chalk from 'chalk';
 
 import { getDataDir } from '#/utils/paths';
+import { checkAgentDesktop, installAgentDesktop } from '#/cli/agent-desktop';
 import type { ColorPalette } from '#/tui/theme/colors';
 import { SELECT_POINTER } from '../constant/symbols';
 import type { SlashCommandHost } from './dispatch';
@@ -29,9 +31,19 @@ interface McpRecommendation {
   description: string;
   command: string;
   args: string[];
+  /** If true, only available on macOS */
+  macOnly?: boolean;
 }
 
 const RECOMMENDED: McpRecommendation[] = [
+  {
+    name: 'agent-desktop',
+    displayName: 'Desktop Automation',
+    description: 'macOS 桌面自动化：截图/点击/键入/滚动/窗口管理（需辅助功能权限）',
+    command: 'scream-desktop-mcp',
+    args: [],
+    macOnly: true,
+  },
   {
     name: 'playwright',
     displayName: 'Playwright',
@@ -42,6 +54,23 @@ const RECOMMENDED: McpRecommendation[] = [
 ];
 
 // ─── 状态映射 ─────────────────────────────────────────────────────────
+
+/** Resolve scream-desktop-mcp to an absolute path. In development the bin is
+ *  not on PATH; resolve relative to the main dist entry. In production (global
+ *  npm install) the bin link works directly. */
+function resolveDesktopMcpCommand(): { command: string; args: string[] } {
+  // Try development path first: resolve relative to the running main script.
+  // main.mjs is `dist/main.mjs`; desktop-server.mjs is `dist/mcp-servers/desktop-server.mjs`.
+  const candidates = [
+    join(dirname(process.argv[1] ?? ''), 'mcp-servers', 'desktop-server.mjs'),
+    // Also try the tsx dev path: src/main.ts → src/mcp-servers/desktop-server.ts
+    join(dirname(process.argv[1] ?? ''), 'mcp-servers', 'desktop-server.ts'),
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return { command: process.execPath, args: [p] };
+  }
+  return { command: 'scream-desktop-mcp', args: [] };
+}
 
 const STATUS_LABELS: Record<string, string> = {
   pending: '⏳ 连接中',
@@ -142,7 +171,11 @@ function buildRows(
   servers: readonly { name: string; status: string; toolCount: number; error?: string }[],
 ): McpRow[] {
   const rows: McpRow[] = [];
-  const installedNames = new Set(servers.map((s) => s.name));
+  // A server that's installed but in a failed state should still be
+  // retryable — don't mark it "already installed" in recommendations.
+  const installedNames = new Set(
+    servers.filter((s) => s.status !== 'failed').map((s) => s.name),
+  );
 
   if (servers.length > 0) {
     rows.push({ kind: 'installed', name: '', label: '── 已安装 ──', status: '__section' });
@@ -169,14 +202,17 @@ function buildRows(
   rows.push({ kind: 'recommended', name: '', label: '── 推荐 MCP（Enter 安装）──', status: '__section' });
   for (const rec of RECOMMENDED) {
     const alreadyInstalled = installedNames.has(rec.name);
+    const platformUnavailable = rec.macOnly && process.platform !== 'darwin';
     rows.push({
       kind: 'recommended',
       name: rec.name,
       label: rec.displayName,
-      description: alreadyInstalled
-        ? `${rec.description}  [已安装]`
-        : `${rec.description}  [Enter 安装]`,
-      alreadyInstalled,
+      description: platformUnavailable
+        ? `${rec.description}  [仅支持 macOS]`
+        : alreadyInstalled
+          ? `${rec.description}  [已安装]`
+          : `${rec.description}  [Enter 安装]`,
+      alreadyInstalled: alreadyInstalled || platformUnavailable,
     });
   }
 
@@ -251,12 +287,38 @@ async function installMcp(host: SlashCommandHost, rec: McpRecommendation): Promi
   if (!session) return;
 
   const spinner = host.showProgressSpinner(`正在安装 ${rec.displayName}...`);
+
+  // agent-desktop: ensure the native binary is installed first
+  if (rec.name === 'agent-desktop') {
+    try {
+      const status = await checkAgentDesktop();
+      if (!status.installed) {
+        spinner.setLabel('正在安装 agent-desktop 二进制...');
+        const result = await installAgentDesktop();
+        if (!result.ok) {
+          spinner.stop({ ok: false, label: 'agent-desktop 二进制安装失败。' });
+          host.showError(`agent-desktop 安装失败：${result.output}`);
+          return;
+        }
+      }
+    } catch (error) {
+      spinner.stop({ ok: false, label: 'agent-desktop 检测失败。' });
+      host.showError(`agent-desktop 检测失败：${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
+  }
+
+  spinner.setLabel(`正在配置 ${rec.displayName}...`);
   try {
-    await writeMcpConfig(host, rec.name, rec.command, rec.args);
+    // Resolve the actual command path (dev: local build, production: npm bin).
+    const resolved = rec.name === 'agent-desktop'
+      ? resolveDesktopMcpCommand()
+      : { command: rec.command, args: rec.args };
+    await writeMcpConfig(host, rec.name, resolved.command, resolved.args);
     await session.addMcpServer(rec.name, {
       transport: 'stdio',
-      command: rec.command,
-      args: rec.args,
+      command: resolved.command,
+      args: resolved.args,
     });
     spinner.stop({ ok: true, label: `${rec.displayName} 安装成功并已启动。` });
   } catch (error) {

--- a/apps/scream-code/tsdown.config.ts
+++ b/apps/scream-code/tsdown.config.ts
@@ -9,7 +9,7 @@ const appRoot = import.meta.dirname;
 const repoRoot = resolve(appRoot, '../..');
 
 export default defineConfig({
-  entry: ['./src/main.ts'],
+  entry: ['./src/main.ts', './src/mcp-servers/desktop-server.ts'],
   format: ['esm'],
   outDir: 'dist',
   clean: true,


### PR DESCRIPTION
## 概述

将 `/computer` 桌面自动化功能改造为 MCP 插件，与现有 `/mcp` 管理体系统一。

### 效果

| | 改造前 | 改造后 |
|---|---|---|
| 安装 | `/computer` → Install → Start | `/mcp` → Enter Desktop |
| 工具发现 | DesktopRunner 手动注入 | MCP 协议自动发现 |
| 安全性 | 不 Start 工具就不存在 | 不装 MCP 工具就不存在 |

### 改动

- 新建 `scream-desktop-mcp` stdio server（`mcp-servers/desktop-server.ts`），注册 13 个工具（12 个 computer_* + computer_skill 指南）
- `/mcp` 面板集成 Desktop Automation 推荐安装
- 修复 agent-desktop CLI 参数映射（位置参数、下划线转连字符、布尔标志）
- 修复开发环境路径解析和全局 fallback 状态
- 清理旧的 DesktopRunner 注入代码